### PR TITLE
use watchCollection instead of watchGroup

### DIFF
--- a/topology-graph.js
+++ b/topology-graph.js
@@ -294,7 +294,7 @@
                             graph.kinds(value);
                         });
 
-                        $scope.$watchGroup(["items", "relations"], function(values) {
+                        $scope.$watchCollection('[items, relations]', function(values) {
                             graph.data(values[0], values[1]);
                         });
 


### PR DESCRIPTION
watchGroup method exists only starting Angular 1.3.
Hence, using the graph with watchGroup in code with an older Angular (1.2.x) fails.
