### PR TITLE
Downgrade d3 version from 3.5.5 to 3.5.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,7 +28,7 @@
   ],
   "dependencies": {
     "angular": "~1.3.8",
-    "d3": "~3.5.5"
+    "d3": "3.5.0"
   },
   "devDependencies": {
     "patternfly": "~1.2.1",


### PR DESCRIPTION
This is required since the latest c3 relies on <=3.5.0,
and manageiq uses c3, so the dependency for D3 being both
3.5.5 and <=3.5.0 cannot be satisfied.
