### PR TITLE
Fix default selection behavior with angularjs 1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,8 @@ event, and change the selection.
 
 This is a scope event that will be emitted when the selection changes. The argument will
 be the item (from the ```items``` map) that is being select, or ```null``` if nothing is
-selected.
+selected. You can call ```event.preventDefault()``` during this event to prevent the default
+selection behavior.
 
 #### force
 Optional. A D3 force layout to use instead of creating one by default. The force layout size

--- a/topology-graph.js
+++ b/topology-graph.js
@@ -286,7 +286,7 @@
 
                         function notify(item) {
                             $scope.$emit("select", item);
-                            if (!("selection" in attributes))
+                            if (attributes["selection"] === undefined)
 	                        graph.select(item);
                         }
 

--- a/topology-graph.js
+++ b/topology-graph.js
@@ -285,8 +285,8 @@
                         element.css("display", "block");
 
                         function notify(item) {
-                            $scope.$emit("select", item);
-                            if (attributes["selection"] === undefined)
+                            var event = $scope.$emit("select", item);
+                            if (attributes["selection"] === undefined && !event.defaultPrevented)
 	                        graph.select(item);
                         }
 


### PR DESCRIPTION
In addition allow the 'select' event.preventDefault() in order
to prevent the default selection behavior.
