### PR TITLE
Improving positioning of icons

### DIFF
--- a/dist/topology-graph.css
+++ b/dist/topology-graph.css
@@ -31,7 +31,6 @@ kubernetes-topology-graph {
 
 .kube-topology g.Service text {
     fill: #ff7f0e;
-    transform: translate(-3px,-1px)
 }
 
 .kube-topology g.ReplicationController text {

--- a/index.html
+++ b/index.html
@@ -87,19 +87,19 @@
       <defs>
         <g class="Node" id="vertex-Node">
           <circle r="15"></circle>
-          <text y="9">&#xe621;</text>
+          <text y="7">&#xe621;</text>
         </g>
         <g class="Pod" id="vertex-Pod">
           <circle r="15"></circle>
-          <text y="6" x="0.5">&#xf1b3;</text>
+          <text y="5" x="0.5">&#xf1b3;</text>
         </g>
         <g class="Service" id="vertex-Service">
           <circle r="15"></circle>
-          <text y="10" x="1">&#xe61e;</text>
+          <text y="8" x="-2">&#xe61e;</text>
         </g>
         <g class="ReplicationController" id="vertex-ReplicationController">
           <circle r="15"></circle>
-          <text y="9">&#xe624;</text>
+          <text y="7.5" x="-1">&#xe624;</text>
         </g>
       </defs>
     </svg>

--- a/topology-graph.css
+++ b/topology-graph.css
@@ -31,7 +31,6 @@ kubernetes-topology-graph {
 
 .kube-topology g.Service text {
     fill: #ff7f0e;
-    transform: translate(-3px,-1px)
 }
 
 .kube-topology g.ReplicationController text {


### PR DESCRIPTION
When [PatternFly's container icons changed](https://github.com/patternfly/patternfly/releases/tag/v2.9.0), the rendering of the service icon in topology-graph became very off-centered, and the most backwards-compatible-friendly fix was to simply [use CSS to reposition the icon](https://github.com/rhamilto/topology-graph/blob/38a3f844abfa3ac28f7fc0ac1e3233f0c45cc8ac/dist/topology-graph.css#L34).  The downside to that approach is that it doesn't work in IE.  This PR is to properly fix the alignment of the service icon, and improve the alignment of the other icons as well.  

**Important:**  because these fixes are to the SVG defs that are not part of the distributed code, any downstream consumers of this package will need to [update their SVG defs](https://github.com/rhamilto/topology-graph/blob/bdc2a53731bd340fbe85b1d33723656d19942724/index.html#L87) manually.

Before:
![before](https://cloud.githubusercontent.com/assets/895728/18363389/ec31005c-75d7-11e6-9302-0833181c943a.png)

After:
![after](https://cloud.githubusercontent.com/assets/895728/18363397/f1b88ad6-75d7-11e6-89cf-38a9c143ae30.png)

cc: @jwforres, @spadgett
