### PR TITLE
kubernetes: Fix use of SVG <use> tags in topology view

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,20 +86,20 @@
     <svg class="kube-topology" hidden>
       <defs>
         <g class="Node" id="vertex-Node">
-          <circle r="15"></circle>
-          <text y="7">&#xe621;</text>
+          <circle r="15" fill="#fff" stroke="#aaa"></circle>
+          <text y="7" fill="#636363" font-family="PatternFlyIcons-webfont" font-size="18px" text-anchor="middle">&#xe621;</text>
         </g>
         <g class="Pod" id="vertex-Pod">
-          <circle r="15"></circle>
-          <text y="5" x="0.5">&#xf1b3;</text>
+          <circle r="15" fill="#fff" stroke="#aaa"></circle>
+          <text y="5" x="0.5" fill="#1186C1" font-family="FontAwesome" font-size="16px" text-anchor="middle">&#xf1b3;</text>
         </g>
         <g class="Service" id="vertex-Service">
-          <circle r="15"></circle>
-          <text y="8" x="-2">&#xe61e;</text>
+          <circle r="15" fill="#fff" stroke="#aaa"></circle>
+          <text y="8" x="-2" fill="#ff7f0e" font-family="PatternFlyIcons-webfont" font-size="18px" text-anchor="middle">&#xe61e;</text>
         </g>
         <g class="ReplicationController" id="vertex-ReplicationController">
-          <circle r="15"></circle>
-          <text y="7.5" x="-1">&#xe624;</text>
+          <circle r="15" fill="#fff" stroke="#aaa"></circle>
+          <text y="7.5" x="-1" fill="#9467bd" font-family="PatternFlyIcons-webfont" font-size="20px" text-anchor="middle">&#xe624;</text>
         </g>
       </defs>
     </svg>

--- a/topology-graph.css
+++ b/topology-graph.css
@@ -19,30 +19,6 @@ kubernetes-topology-graph {
     opacity: .6;
 }
 
-.kube-topology g.Pod text {
-    font-family: FontAwesome;
-    font-size: 16px;
-    fill: #1186C1;
-}
-
-.kube-topology g.Node text {
-    fill: #636363;
-}
-
-.kube-topology g.Service text {
-    fill: #ff7f0e;
-}
-
-.kube-topology g.ReplicationController text {
-    fill: #9467bd;
-    font-size: 20px;
-}
-
-.kube-topology g circle {
-    stroke: #aaa;
-    fill: #fff;
-}
-
 .kube-topology g.fixed use {
     stroke-width: 2px;
 }
@@ -87,3 +63,4 @@ kubernetes-topology-icon.active use {
 kubernetes-topology-icon:hover use {
     opacity: 0.7;
 }
+


### PR DESCRIPTION
The SVG <use> tag applies CSS differently depending on which browser
is in use. We need to include the actual fill, stroke and font
information in the SVG itself in order to reuse it via <use> tags.

In fact half the info (positioning) was already there, so this just
brings all the style related info into one place.