### PR TITLE
Adding kubernetesTopologyFilter directive to handle custom filters

### DIFF
--- a/dist/topology-graph.css
+++ b/dist/topology-graph.css
@@ -19,30 +19,6 @@ kubernetes-topology-graph {
     opacity: .6;
 }
 
-.kube-topology g.Pod text {
-    font-family: FontAwesome;
-    font-size: 16px;
-    fill: #1186C1;
-}
-
-.kube-topology g.Node text {
-    fill: #636363;
-}
-
-.kube-topology g.Service text {
-    fill: #ff7f0e;
-}
-
-.kube-topology g.ReplicationController text {
-    fill: #9467bd;
-    font-size: 20px;
-}
-
-.kube-topology g circle {
-    stroke: #aaa;
-    fill: #fff;
-}
-
 .kube-topology g.fixed use {
     stroke-width: 2px;
 }
@@ -62,6 +38,7 @@ kubernetes-topology-graph {
     stroke-dasharray: 5, 2;
 }
 
+kubernetes-topology-filter,
 kubernetes-topology-icon {
     display: inline-block;
     vertical-align: middle;
@@ -70,20 +47,25 @@ kubernetes-topology-icon {
     user-select: none;
 }
 
+kubernetes-topology-filter svg,
 kubernetes-topology-icon svg {
     width: 32px;
     height: 32px;
     display: block;
 }
 
+kubernetes-topology-filter use,
 kubernetes-topology-icon use {
     opacity: 0.4;
 }
 
+kubernetes-topology-filter.active use,
 kubernetes-topology-icon.active use {
     opacity: 1;
 }
 
+kubernetes-topology-filter:hover use,
 kubernetes-topology-icon:hover use {
     opacity: 0.7;
 }
+

--- a/topology-graph.css
+++ b/topology-graph.css
@@ -38,6 +38,7 @@ kubernetes-topology-graph {
     stroke-dasharray: 5, 2;
 }
 
+kubernetes-topology-filter,
 kubernetes-topology-icon {
     display: inline-block;
     vertical-align: middle;
@@ -46,20 +47,24 @@ kubernetes-topology-icon {
     user-select: none;
 }
 
+kubernetes-topology-filter svg,
 kubernetes-topology-icon svg {
     width: 32px;
     height: 32px;
     display: block;
 }
 
+kubernetes-topology-filter use,
 kubernetes-topology-icon use {
     opacity: 0.4;
 }
 
+kubernetes-topology-filter.active use,
 kubernetes-topology-icon.active use {
     opacity: 1;
 }
 
+kubernetes-topology-filter:hover use,
 kubernetes-topology-icon:hover use {
     opacity: 0.7;
 }

--- a/topology-graph.js
+++ b/topology-graph.js
@@ -33,6 +33,8 @@
 
         /* Kinds of objects to show */
         var kinds = null;
+        /* Filters to hide items */
+        var filters = null;
 
         /* Data we've been fed */
         var items = { };
@@ -167,6 +169,27 @@
             return added;
         }
 
+        /**
+          * Evaluates if an item should be displayed on topology graph.
+          *
+          * @param {JSON} item - item to be evaluated.
+          *
+          * @return true if the item should be displayed.
+          */
+         function isDisplayable(item) {
+            if (kinds && !kinds[item.kind])
+                return false;
+
+            for (var filter in filters){
+                if (filters.hasOwnProperty(filter)) {
+                    if (item[filter] && filters[filter].includes(item[filter]))
+                        return false;
+                }
+            }
+
+            return true;
+        }
+
         function digest() {
             var pnodes = nodes;
             var plookup = lookup;
@@ -176,12 +199,11 @@
             links = [];
             lookup = { };
 
-            var item, id, kind, node;
+            var item, id, node;
             for (id in items) {
                 item = items[id];
-                kind = item.kind;
 
-                if (kinds && !kinds[kind])
+                if (!isDisplayable(item))
                     continue;
 
                 /* Prevents flicker */
@@ -230,12 +252,17 @@
 
         return {
             select: select,
+            filters: function(value) {
+                filters = value;
+                var added = digest();
+                return [vertices, added];
+            },
             kinds: function(value) {
                 kinds = value;
                 var added = digest();
                 return [vertices, added];
             },
-	    data: function(new_items, new_relations) {
+	        data: function(new_items, new_relations) {
                 items = new_items || { };
                 relations = new_relations || [];
                 var added = digest();
@@ -275,6 +302,7 @@
                         items: '=',
                         relations: '=',
                         kinds: '=',
+                        filters: '=',
                         selection: '=',
                         force: '=',
                         radius: '='
@@ -330,6 +358,10 @@
                             render(graph.kinds(value));
                         });
 
+                        $scope.$watch("filters", function(value) {
+                            render(graph.filters(value));
+                        }, true);
+
                         $scope.$watchCollection('[items, relations]', function(values) {
                             render(graph.data(values[0], values[1]));
                         });
@@ -371,6 +403,59 @@
                             if ($scope.$parent)
 	                        $scope.$parent.$digest();
 	                    $scope.$digest();
+                        });
+                    }
+                };
+            }
+        )
+
+        /**
+         * Filters the topology items.
+         * When click on this component it will activate/disable the filter properties and remove
+         * those items that corresponds to the disabled filters.
+         *
+         * ATTRIBUTES:
+         * - filterProperty: corresponds to the name of item property that will be evaluated to filter
+         * - filterValue: the value of item property to filter
+         *                if the item property has this value, the item will be impacted.
+         *                it accepts more than one value (comma separated)
+         */
+        .directive('kubernetesTopologyFilter',
+            function() {
+                return {
+                    restrict: 'E',
+                    transclude: true,
+                    template: "<ng-transclude></ng-transclude>",
+                    link: function($scope, element, attrs) {
+                        var filterProperty = attrs.filterProperty;
+                        var filterValue = attrs.filterValue.split(',');
+                        $scope.filters[filterProperty] = $scope.filters[filterProperty] || [];
+
+                        var filteredValues = $scope.filters[filterProperty];
+
+                        $scope.$watchCollection("filters." + filterProperty, function() {
+                            element.toggleClass("active", filterValue.some(function(value) {
+                                return !filteredValues.includes(value)
+                            }));
+                        });
+
+                        element.on("click", function() {
+                            $scope.filters[filterProperty] = $scope.filters[filterProperty] || [];
+
+                            filterValue.forEach(function(value) {
+                                var index = filteredValues.indexOf(value);
+
+                                if (index > -1) {
+                                    filteredValues.splice(index, 1);
+                                } else {
+                                    filteredValues.push(value);
+                                }
+                            });
+
+                            if ($scope.$parent)
+                                $scope.$parent.$digest();
+
+                            $scope.$digest();
                         });
                     }
                 };


### PR DESCRIPTION
__This PR is able to__
- Add `kubernetesTopologyFilter` directive to handle custom filters;

__Usage__
```html
<kubernetes-topology-filter 
  tooltip-placement="bottom"
  uib-tooltip="<custom filter tooltip>"
  filter-property="<item property name to filter>"
  filter-value="<item property value to filter>"
></kubernetes-topology-filter>
```

__Example__
With an item list with those data
```javascript
my_items = {
    item1: { kind: "Node", status: "Warning" },
    item2: { kind: "Pod", status: "Critical" }
}
```
We can use this directive this way:
```html
<kubernetes-topology-filter 
  tooltip-placement="bottom"
  uib-tooltip="Hide elements with Warning status"
  filter-property="status"
  filter-value="Warning"
></kubernetes-topology-filter>
```
When click on directive, the items with `Warning` status will be hide from topology.

__Replacing kubernetes-topology-icon__
This new directive also can replace the old `kubernetes-topology-icon`, just using this way:
```html
<kubernetes-topology-filter 
  tooltip-placement="bottom"
  uib-tooltip="Hide Pod elements"
  filter-property="kind"
  filter-value="Pod"
></kubernetes-topology-filter>
```
This way, when click on directive, the Pod items will be hide.

**P.S. [Here](https://github.com/ManageIQ/manageiq-ui-classic/pull/4396) is possible to see the usage of this new directive.**